### PR TITLE
Added larger limit to file viewing

### DIFF
--- a/client/src/ImportStudentsView/ImportStudents.js
+++ b/client/src/ImportStudentsView/ImportStudents.js
@@ -63,7 +63,7 @@ const ImportStudents = () => {
             columns={columns}
             data={data}
             muiTablePaginationProps={{
-              rowsPerPageOptions: [5,50,100,150,200,250],
+              rowsPerPageOptions: [-1],
               showFirstButton: false,
               showLastButton: false,
             }}

--- a/client/src/ImportStudentsView/ImportStudents.js
+++ b/client/src/ImportStudentsView/ImportStudents.js
@@ -62,6 +62,11 @@ const ImportStudents = () => {
           <MaterialReactTable
             columns={columns}
             data={data}
+            muiTablePaginationProps={{
+              rowsPerPageOptions: [5,50,100,150,200,250],
+              showFirstButton: false,
+              showLastButton: false,
+            }}
             renderTopToolbarCustomActions={() => (
                 <FormControl>
                 <Box sx={{ display: 'flex', gap: '1rem', p: '0.5rem'}}>

--- a/client/src/ProjectListingView/Components/ProjectTable/ProjectTable.js
+++ b/client/src/ProjectListingView/Components/ProjectTable/ProjectTable.js
@@ -247,6 +247,11 @@ const ProjectTable = () => {
             size: 120,
           },
         }}
+        muiTablePaginationProps={{
+          rowsPerPageOptions: [5,50,100,150,200,250],
+          showFirstButton: false,
+          showLastButton: false,
+        }}
         columns={columns}
         data={tableData}
         editingMode="modal"

--- a/client/src/ProjectListingView/Components/ProjectTable/ProjectTable.js
+++ b/client/src/ProjectListingView/Components/ProjectTable/ProjectTable.js
@@ -248,7 +248,7 @@ const ProjectTable = () => {
           },
         }}
         muiTablePaginationProps={{
-          rowsPerPageOptions: [5,50,100,150,200,250],
+          rowsPerPageOptions: [-1],
           showFirstButton: false,
           showLastButton: false,
         }}


### PR DESCRIPTION
the prof said they wanted basically the entire table visible at once so i raised the cap to 250

### Change Description
more rows per page

### How to Verify
download this branch
run the client portion
attempt to edit the rows per page
250

### Verification
you selected 250 (yay)
