### PR TITLE
Chore: Add import students button to Navbar

### DIFF
--- a/client/src/HomePageView/HomePage.js
+++ b/client/src/HomePageView/HomePage.js
@@ -23,7 +23,7 @@ const useStyles = makeStyles((theme) => ({
     },
     media: {
         height: 0,
-        paddingTop: "56.25%", // 16:9 aspect ratio
+        paddingTop: "75%", // 16:9 aspect ratio
     },
 }));
 const HomePage = () => {
@@ -39,12 +39,12 @@ const HomePage = () => {
                         We are a company that specializes in managing academic teams.
                     </Typography>
                 </Grid>
-                <Grid item  sm={4} className={classes.column2}>
+                <Grid item  sm={3} className={classes.column2}>
                     <Card className={classes.card} style={{boxShadow: '0px 3px 5px rgba(0,0,0,0.2)'}}>
                         <CardMedia
                             className={classes.media}
-                            image="https://source.unsplash.com/random"
-                            title="Random image"
+                            image="https://upload.wikimedia.org/wikipedia/en/5/5f/Uottawacoa.svg"
+                            title="uottawa logo"
                         />
                     </Card>
                 </Grid>

--- a/client/src/StaticComponents/NavBar/ResponsiveAppBar.js
+++ b/client/src/StaticComponents/NavBar/ResponsiveAppBar.js
@@ -10,8 +10,7 @@ const pages = {
   page1: {key: 'Home', value:'/'},
   page2: {key: 'Projects', value:'/Projects'},
   page3: {key:'Groups', value:'/GroupView'},
-  page4: {key:'Import Students', value:'/ImportStudents'},
-  page5: {key: 'Students', value:'/Students'}
+  page4: {key: 'Students', value:'/Students'}
 };
 
 function ResponsiveAppBar() {

--- a/client/src/StudentListingView/StudentTable.js
+++ b/client/src/StudentListingView/StudentTable.js
@@ -26,6 +26,7 @@ import {
   FormGroup,
 } from '@mui/material';
 import FileDownloadIcon from '@mui/icons-material/FileDownload';
+import FileUploadIcon from '@mui/icons-material/FileUpload';
 import { ExportToCsv } from 'export-to-csv';
 import { Delete, Edit, Help } from '@mui/icons-material';
 import { createTheme } from '@mui/material/styles';
@@ -254,6 +255,14 @@ const StudentTable = () => {
             variant="contained"
             >
               Export All Data
+            </Button>
+            <Button
+              color="secondary"
+              startIcon={<FileUploadIcon />}
+              href="/ImportStudents"
+              variant="contained"
+            >
+              Import Students
             </Button>
           </Box>
         )}


### PR DESCRIPTION
### Change Description
<!-- Explain the changes you made. -->
- Removed the "Import Students" route from the navbar
- Added a new button that redirects to "Import Students" component
- Changed the image in the homepage with the Ottawa official logo

### Screenshots
![image](https://user-images.githubusercontent.com/59850587/227849082-3c590310-a8ea-4349-ae97-a02b775f7e5b.png)

![image](https://user-images.githubusercontent.com/59850587/227849092-2bb66823-f60a-4a9e-90d8-23e26113d73d.png)


### Related PR/Issues, JIRAs
<!-- Related Issues, PRs, etc. -->
closes: 

### How to Verify
<!-- Explain how a reviewer can verify this works -->

### Verification
 - [ ] PR/Change is verified in local dev environment

### Tests
 - [ ] Unit tests added/updated
 - [ ] Integration tests added/updated
