### PR TITLE
Feat: Add locking groups feature

### DIFF
--- a/client/cypress/e2e/GroupForm.cy.js
+++ b/client/cypress/e2e/GroupForm.cy.js
@@ -19,6 +19,7 @@ const student = [
 describe("Submit Group Form", () => {
   let body_id; // Declare a variable to store body_id
   let project_id; // Declare a variable to store project_id
+  let section_id;
   beforeEach(() => {
     cy.visit("http://localhost:3000");
 
@@ -89,6 +90,25 @@ describe("Submit Group Form", () => {
       project_id = response.body;
       expect(response.status).to.equal(200);
     });
+
+    // Add a section
+    cy.request({
+      method: "POST",
+      url: "/api/section", // Replace with the correct URL for the student endpoint
+      body: {
+        name: "Fall 2023 Test",
+        term: "Fall",
+        year: "2023",
+        note: "new section",
+      }, // Adjust the request body as needed
+      headers: {
+        "Content-Type": "application/json",
+      },
+    }).then((response) => {
+      section_id = response.body;
+      expect(response.status).to.equal(201);
+    });
+
     // Define the group data
     const groupData = {
       group_id: "your-group-id", // Replace with your desired group ID
@@ -112,6 +132,10 @@ describe("Submit Group Form", () => {
       .contains("300111311 - username1 Lastname1") // Find the element with the specified text
       .click();
     cy.get("body").click();
+
+    // Select the section
+    cy.get('[name="sections"]').parent().click();
+    cy.get('[role="option"]').contains('Fall 2023 Test').click();
 
     cy.get('div[aria-labelledby="project-label mui-component-select-project"]') // Select the <div> element by its aria-labelledby attribute
       .click(); // Click the element
@@ -153,6 +177,13 @@ describe("Submit Group Form", () => {
     cy.request({
       method: "DELETE",
       url: `/api/project/delete/${project_id}`,
+    }).then((response) => {
+      expect(response.status).to.equal(200);
+    });
+
+    cy.request({
+      method: "DELETE",
+      url: `/api/section/delete/${section_id}`,
     }).then((response) => {
       expect(response.status).to.equal(200);
     });

--- a/client/src/components/adminComponents/forms/StaffForm.js
+++ b/client/src/components/adminComponents/forms/StaffForm.js
@@ -43,6 +43,9 @@ const StaffForm = ({
       if (update) {
         await staffService.update(editingRow._id, values)
       } else {
+        if (values.email) {
+          values.email = values.email.toLowerCase()
+        }
         await staffService.add(values)
       }
       fetchStaffs()
@@ -101,6 +104,25 @@ const StaffForm = ({
               }}
             >
               {columns.map((column) => {
+                if (update && column.accessorKey === 'email') {
+                  return (
+                    <TextField
+                      key={column.accessorKey}
+                      disabled={true}
+                      label={column.header}
+                      name={column.accessorKey}
+                      value={values[column.accessorKey]}
+                      onChange={handleChange}
+                      onBlur={handleBlur}
+                      error={Boolean(
+                        touched[column.accessorKey] && errors[column.accessorKey]
+                      )}
+                      helperText={
+                        touched[column.accessorKey] && errors[column.accessorKey]
+                      }
+                    />
+                  )
+                }
                 if (column.accessorKey === 'role') {
                   return (
                     <FormGroup>

--- a/client/src/components/professorComponents/forms/EditGroupModal.js
+++ b/client/src/components/professorComponents/forms/EditGroupModal.js
@@ -28,6 +28,7 @@ const EditGroupModal = ({
   columns,
   projects,
   students,
+  sections,
   groups,
   setEditModalOpen,
   groupData,
@@ -237,6 +238,36 @@ const EditGroupModal = ({
                       {projects.map((option) => (
                         <MenuItem key={option.project} value={option.project}>
                           {option.project}
+                        </MenuItem>
+                      ))}
+                    </Select>
+                  </FormControl>
+                )
+              }
+
+              if (column.accessorKey === 'sections') {
+                return (
+                  <FormControl>
+                    <InputLabel id="section-label">{t('common.Section')}</InputLabel>
+                    <Select
+                      labelId="section-label"
+                      key={column.accessorKey}
+                      name={column.accessorKey}
+                      defaultValue={groupData.original.sections}
+                      onChange={handleChange}
+                      onBlur={handleBlur}
+                      error={Boolean(
+                        touched[column.accessorKey] &&
+                          errors[column.accessorKey]
+                      )}
+                      helperText={
+                        touched[column.accessorKey] &&
+                        errors[column.accessorKey]
+                      }
+                    >
+                      {sections.map((option) => (
+                        <MenuItem key={option.name} value={option.name}>
+                          {option.name}
                         </MenuItem>
                       ))}
                     </Select>

--- a/client/src/components/professorComponents/forms/GroupForm.js
+++ b/client/src/components/professorComponents/forms/GroupForm.js
@@ -30,6 +30,7 @@ const GroupForm = ({
   fetchData,
   projects,
   students,
+  sections,
   groups,
   setCreateModalOpen,
   update,
@@ -231,6 +232,38 @@ const GroupForm = ({
                         {projects.map((option) => (
                           <MenuItem key={option.project} value={option.project}>
                             {option.project}
+                          </MenuItem>
+                        ))}
+                      </Select>
+                    </FormControl>
+                  )
+                }
+
+                if (column.accessorKey === 'sections') {
+                  return (
+                    <FormControl>
+                      <InputLabel id="section-label">
+                        {t('common.Section')}
+                      </InputLabel>
+                      <Select
+                        labelId="section-label"
+                        key={column.accessorKey}
+                        name={column.accessorKey}
+                        value={values[column.accessorKey]}
+                        onChange={handleChange}
+                        onBlur={handleBlur}
+                        error={Boolean(
+                          touched[column.accessorKey] &&
+                            errors[column.accessorKey]
+                        )}
+                        helperText={
+                          touched[column.accessorKey] &&
+                          errors[column.accessorKey]
+                        }
+                      >
+                        {sections.map((option) => (
+                          <MenuItem key={option.name} value={option.name}>
+                            {option.name}
                           </MenuItem>
                         ))}
                       </Select>

--- a/client/src/components/professorComponents/forms/SectionForm.js
+++ b/client/src/components/professorComponents/forms/SectionForm.js
@@ -5,7 +5,9 @@ import {
   DialogContent,
   Stack,
   TextField,
-  DialogActions
+  DialogActions,
+  Switch,
+  FormControl
 } from '@mui/material'
 import React, { useState } from 'react'
 import { useFormik } from 'formik'
@@ -13,7 +15,7 @@ import sectionService from '../../../services/sectionService'
 import Section from '../../../entities/Section'
 import sectionSchema from '../../../schemas/sectionSchema'
 import { useTranslation } from 'react-i18next'
-import { CircularProgress } from '@material-ui/core'
+import { CircularProgress, InputLabel } from '@material-ui/core'
 
 const SectionForm = ({
   open,
@@ -28,11 +30,13 @@ const SectionForm = ({
 }) => {
   // This use state is to show loading icon when pressing submit on the form to make sure it doesnt hang
   const [isLoading, setIsLoading] = useState(false)
+  const [lockSwitch, setLockSwitch] = useState(editingRow.lock ?? false)
 
   const onSubmit = async (values, actions) => {
     setIsLoading(true)
     try {
       if (update) {
+        values.lock = lockSwitch
         await sectionService.update(editingRow._id, values)
       } else {
         await sectionService.add(values)
@@ -94,8 +98,21 @@ const SectionForm = ({
                 gap: '1.5rem'
               }}
             >
-              {columns.map((column) => (
-                <TextField
+              {columns.map((column) => {
+                if (update && column.accessorKey === 'lock') {
+                  return (
+                    <FormControl>
+                      <InputLabel id="section-label">{t('common.lock-groups')}</InputLabel>
+                      <Switch
+                        checked={lockSwitch}
+                        onChange={() => setLockSwitch(!lockSwitch)}
+                        inputProps={{ 'aria-label': 'controlled' }}
+                      />
+                    </FormControl>
+                  )
+                }
+                return (
+                  <TextField
                   key={column.accessorKey}
                   label={column.header}
                   name={column.accessorKey}
@@ -109,7 +126,8 @@ const SectionForm = ({
                     touched[column.accessorKey] && errors[column.accessorKey]
                   }
                 />
-              ))}
+                )
+              })}
             </Stack>
           </DialogContent>
           <DialogActions sx={{ p: '1.25rem' }}>

--- a/client/src/components/professorComponents/forms/StudentForm.js
+++ b/client/src/components/professorComponents/forms/StudentForm.js
@@ -49,6 +49,9 @@ const StudentForm = ({
   const onSubmit = async (values, actions) => {
     try {
       setIsLoading(true)
+      if (values.email) {
+        values.email = values.email.toLowerCase()
+      }
       await studentService.add(values)
       fetchStudents()
     } catch (error) {

--- a/client/src/components/professorComponents/tables/GroupTable.js
+++ b/client/src/components/professorComponents/tables/GroupTable.js
@@ -17,6 +17,7 @@ import { csvOptions, handleExportData } from '../../../helpers/exportData'
 import groupService from '../../../services/groupService'
 import projectService from '../../../services/projectService'
 import studentService from '../../../services/studentService'
+import sectionService from '../../../services/sectionService'
 import GroupForm from '../forms/GroupForm'
 import ConfirmDeletionModal from '../../common/ConfirmDeletionModal'
 import EditGroupModal from '../forms/EditGroupModal'
@@ -35,6 +36,7 @@ const GroupTable = () => {
   const [tableData, setTableData] = useState([])
   const [projects, setProjects] = useState([])
   const [students, setStudents] = useState([])
+  const [sections, setSections] = useState([])
   const [message] = useState('')
   const [deletion, setDeletion] = useState(false)
   const [row, setDeleteRow] = useState()
@@ -161,6 +163,10 @@ const GroupTable = () => {
         }
       },
       {
+        accessorKey: 'sections',
+        header: t('common.Section')
+      },
+      {
         accessorKey: 'notes',
         header: t('section.notes')
       }
@@ -180,6 +186,18 @@ const GroupTable = () => {
       }
     } catch (error) {
       console.error('Error fetching projects:', error)
+    }
+  }
+
+  const fetchSections = async () => {
+    try {
+      const sections = await sectionService.get()
+
+      if (sections.sections && sections.message !== 'Sections list is empty.') {
+        setSections(sections.sections)
+      }
+    } catch (error) {
+      console.error('Error fetching sections:', error)
     }
   }
 
@@ -251,6 +269,7 @@ const GroupTable = () => {
     await fetchProjects()
     await fetchStudents()
     await fetchGroups()
+    await fetchSections()
   }
 
   useEffect(() => {
@@ -359,6 +378,7 @@ const GroupTable = () => {
         fetchData={fetchData}
         projects={projects}
         students={students}
+        sections={sections}
         groups={tableData}
       />
 
@@ -397,6 +417,7 @@ const GroupTable = () => {
           groupData={editingRow}
           projects={[...projects, editingRow.original]}
           students={students}
+          sections={sections}
           groups={tableData}
         />
       )}

--- a/client/src/components/professorComponents/tables/SectionTable.js
+++ b/client/src/components/professorComponents/tables/SectionTable.js
@@ -6,6 +6,7 @@ import FileDownloadIcon from '@mui/icons-material/FileDownload'
 import {
   Box,
   Button,
+  Chip,
   IconButton,
   Tooltip,
   Typography
@@ -53,6 +54,21 @@ const SectionTable = () => {
       {
         accessorKey: 'notes',
         header: t('section.notes')
+      },
+      {
+        accessorKey: 'lock',
+        header: t('common.status'),
+        Cell: ({ cell }) => {
+          if (cell.getValue('lock') === true) {
+            return (
+              <div>
+                <Chip sx = {{ marginBottom: '5px' }} color="error" label={'Locked'}/>
+              </div>
+            )
+          } else {
+            return null
+          }
+        }
       }
     ],
     [currentLanguage]

--- a/client/src/components/studentsComponents/MyGroup.js
+++ b/client/src/components/studentsComponents/MyGroup.js
@@ -5,12 +5,15 @@ import CircularProgress from '@mui/material/CircularProgress'
 import { Link } from 'react-router-dom'
 import Chip from '@mui/material/Chip'
 import MaterialReactTable from 'material-react-table'
+import LockIcon from '@mui/icons-material/Lock'
+import LockOpenIcon from '@mui/icons-material/LockOpen'
 import { fetchData } from '../../services/api'
 import { colorStatus } from '../../helpers/statusColors'
 import { useTranslation } from 'react-i18next'
 import { MRT_Localization_EN } from 'material-react-table/locales/en'
 import { MRT_Localization_FR } from 'material-react-table/locales/fr'
 import projectService from '../../services/projectService'
+import groupService from '../../services/groupService'
 
 const MyGroup = () => {
   const [group, setGroup] = useState({})
@@ -18,6 +21,7 @@ const MyGroup = () => {
   const [loading, setIsLoading] = useState(false)
   const [applications, setProjectApplications] = useState({})
   const [showAlert, setShowAlert] = useState(false)
+  const [isGroupStudentLocked, setIsGroupStudentLocked] = useState(false)
   const { t, i18n } = useTranslation()
   const currentLanguage = i18n.language
 
@@ -36,6 +40,9 @@ const MyGroup = () => {
     try {
       const groupData = await fetchData('api/retrieve/curr/user/group')
       !groupData.error && setGroup(groupData)
+      if (groupData.studentLock) {
+        setIsGroupStudentLocked(groupData.studentLock)
+      }
     } catch (error) {
       console.error(error)
       setGroup({})
@@ -71,6 +78,28 @@ const MyGroup = () => {
       projectApplicationsData && setProjectApplications(projectApplicationsData)
     } catch (error) {
       console.error(error)
+    }
+  }
+
+  const handleUnlockingGroup = async () => {
+    try {
+      const res = await groupService.studentUnlockGroup(group)
+      if (res.success) {
+        setIsGroupStudentLocked(false)
+      }
+    } catch (error) {
+      console.log('error', error)
+    }
+  }
+
+  const handleLockingGroup = async () => {
+    try {
+      const res = await groupService.studentLockGroup(group)
+      if (res.success) {
+        setIsGroupStudentLocked(true)
+      }
+    } catch (error) {
+      console.log('error', error)
     }
   }
 
@@ -181,6 +210,36 @@ const MyGroup = () => {
                     <strong>Group ID:</strong>
                   </Typography>
                   <Chip sx = {{ m: '2px' }} key={'group_id'} label={group.group_id} color="warning"></Chip>
+
+              <Typography sx={{ mt: 1 }} gutterBottom>
+                Control who can join your group
+              </Typography>
+              <Grid
+                container
+                spacing={2}
+                alignItems="center"
+              >
+                <Grid item>
+                  <Button
+                    variant="contained"
+                    color="info"
+                    disabled={isGroupStudentLocked}
+                    onClick={handleLockingGroup}
+                  >
+                    <LockIcon /> Lock
+                  </Button>
+                </Grid>
+                <Grid item>
+                  <Button
+                    variant="contained"
+                    color="success"
+                    disabled={!isGroupStudentLocked}
+                    onClick={handleUnlockingGroup}
+                  >
+                    <LockOpenIcon /> Unlock
+                  </Button>
+                </Grid>
+              </Grid>
 
                   <Typography mt={2} sx={{ fontSize: '18px' }}>
                     <strong> {t('my-group.members')}</strong>

--- a/client/src/components/studentsComponents/MyGroup.js
+++ b/client/src/components/studentsComponents/MyGroup.js
@@ -22,6 +22,7 @@ const MyGroup = () => {
   const [applications, setProjectApplications] = useState({})
   const [showAlert, setShowAlert] = useState(false)
   const [isGroupStudentLocked, setIsGroupStudentLocked] = useState(false)
+  const [isGroupProfessorLocked, setIsGroupProfessorLocked] = useState(false)
   const { t, i18n } = useTranslation()
   const currentLanguage = i18n.language
 
@@ -42,6 +43,9 @@ const MyGroup = () => {
       !groupData.error && setGroup(groupData)
       if (groupData.studentLock) {
         setIsGroupStudentLocked(groupData.studentLock)
+      }
+      if (groupData.professorLock) {
+        setIsGroupProfessorLocked(groupData.professorLock)
       }
     } catch (error) {
       console.error(error)
@@ -223,7 +227,7 @@ const MyGroup = () => {
                   <Button
                     variant="contained"
                     color="info"
-                    disabled={isGroupStudentLocked}
+                    disabled={isGroupProfessorLocked || isGroupStudentLocked}
                     onClick={handleLockingGroup}
                   >
                     <LockIcon /> Lock
@@ -233,7 +237,7 @@ const MyGroup = () => {
                   <Button
                     variant="contained"
                     color="success"
-                    disabled={!isGroupStudentLocked}
+                    disabled={isGroupProfessorLocked || !isGroupStudentLocked}
                     onClick={handleUnlockingGroup}
                   >
                     <LockOpenIcon /> Unlock

--- a/client/src/components/studentsComponents/MyGroup.js
+++ b/client/src/components/studentsComponents/MyGroup.js
@@ -211,12 +211,12 @@ const MyGroup = () => {
                 ? (
                 <Box>
                   <Typography mt={2} sx={{ fontSize: '18px' }}>
-                    <strong>Group ID:</strong>
+                    <strong>{t('common.Group')} ID:</strong>
                   </Typography>
                   <Chip sx = {{ m: '2px' }} key={'group_id'} label={group.group_id} color="warning"></Chip>
 
               <Typography sx={{ mt: 1 }} gutterBottom>
-                Control who can join your group
+                {t('my-group.lock-group-message')}
               </Typography>
               <Grid
                 container
@@ -230,7 +230,7 @@ const MyGroup = () => {
                     disabled={isGroupProfessorLocked || isGroupStudentLocked}
                     onClick={handleLockingGroup}
                   >
-                    <LockIcon /> Lock
+                    <LockIcon />{t('common.lock')}
                   </Button>
                 </Grid>
                 <Grid item>
@@ -240,7 +240,7 @@ const MyGroup = () => {
                     disabled={isGroupProfessorLocked || !isGroupStudentLocked}
                     onClick={handleUnlockingGroup}
                   >
-                    <LockOpenIcon /> Unlock
+                    <LockOpenIcon />{t('common.unlock')}
                   </Button>
                 </Grid>
               </Grid>

--- a/client/src/components/studentsComponents/MyGroup.js
+++ b/client/src/components/studentsComponents/MyGroup.js
@@ -322,6 +322,7 @@ const MyGroup = () => {
                       </Grid>
                       <Grid item>
                         <Button
+                          disabled={isGroupProfessorLocked}
                           variant="contained"
                           color="error"
                           onClick={handleLeaveGroup}

--- a/client/src/components/studentsComponents/forms/StudentGroupForm.js
+++ b/client/src/components/studentsComponents/forms/StudentGroupForm.js
@@ -17,7 +17,7 @@ import { useFormik } from 'formik'
 import React, { useState } from 'react'
 import Group from '../../../entities/Group'
 import groupService from '../../../services/groupService'
-import createGroupSchema from '../../../schemas/createGroupSchema'
+import studentCreateGroupSchema from '../../../schemas/studentCreateGroupSchema'
 import { useTranslation } from 'react-i18next'
 
 const StudentGroupForm = ({
@@ -51,6 +51,9 @@ const StudentGroupForm = ({
         await groupService.update(editingRow._id, values)
       } else {
         values.members.push(currentStudent.orgdefinedid)
+        if (currentStudent.sections) {
+          values.sections = currentStudent.sections
+        }
         await groupService.add(values)
       }
       handleClose()
@@ -70,7 +73,7 @@ const StudentGroupForm = ({
     handleSubmit
   } = useFormik({
     initialValues: initialGroupValues.toJSON(),
-    validationSchema: createGroupSchema(groups, editingRow?._id),
+    validationSchema: studentCreateGroupSchema(groups, editingRow?._id),
     onSubmit
   })
 

--- a/client/src/components/studentsComponents/tables/StudentGroupTable.js
+++ b/client/src/components/studentsComponents/tables/StudentGroupTable.js
@@ -336,7 +336,7 @@ const StudentGroupTable = () => {
                 return (
                   <Box sx={{ display: 'flex', gap: '1rem', alignItems: 'center', justifyContent: 'center' }}>
                     <Button onClick={() => handleJoinClick()} disabled={isCurrentUserInGroup || (typeof group !== 'undefined' && row.original.group_id === group) || row.original.members.length >= 5 || row.original.professorLock || row.original.studentLock || (row.original.sections !== currentStudent.sections)}>{t('group-table.join')}</Button>
-                    {row.original.group_id === group && <Button color= "error" onClick={() => handleLeaveGroup()}> {t('common.Leave')} </Button>}
+                    {row.original.group_id === group && <Button disabled={row.original.professorLock} color= "error" onClick={() => handleLeaveGroup()}> {t('common.Leave')} </Button>}
                     <Snackbar open={showAlert} onClose={handleAlertClose} anchorOrigin={{ vertical: 'top', horizontal: 'center' }}>
                       <Alert
                         onClose={handleAlertClose}

--- a/client/src/components/studentsComponents/tables/StudentGroupTable.js
+++ b/client/src/components/studentsComponents/tables/StudentGroupTable.js
@@ -335,7 +335,7 @@ const StudentGroupTable = () => {
 
                 return (
                   <Box sx={{ display: 'flex', gap: '1rem', alignItems: 'center', justifyContent: 'center' }}>
-                    <Button onClick={() => handleJoinClick()} disabled={isCurrentUserInGroup || (typeof group !== 'undefined' && row.original.group_id === group) || row.original.members.length >= 5}>{t('group-table.join')}</Button>
+                    <Button onClick={() => handleJoinClick()} disabled={isCurrentUserInGroup || (typeof group !== 'undefined' && row.original.group_id === group) || row.original.members.length >= 5 || row.original.studentLock}>{t('group-table.join')}</Button>
                     {row.original.group_id === group && <Button color= "error" onClick={() => handleLeaveGroup()}> {t('common.Leave')} </Button>}
                     <Snackbar open={showAlert} onClose={handleAlertClose} anchorOrigin={{ vertical: 'top', horizontal: 'center' }}>
                       <Alert

--- a/client/src/components/studentsComponents/tables/StudentGroupTable.js
+++ b/client/src/components/studentsComponents/tables/StudentGroupTable.js
@@ -335,7 +335,7 @@ const StudentGroupTable = () => {
 
                 return (
                   <Box sx={{ display: 'flex', gap: '1rem', alignItems: 'center', justifyContent: 'center' }}>
-                    <Button onClick={() => handleJoinClick()} disabled={isCurrentUserInGroup || (typeof group !== 'undefined' && row.original.group_id === group) || row.original.members.length >= 5 || row.original.professorLock || row.original.studentLock}>{t('group-table.join')}</Button>
+                    <Button onClick={() => handleJoinClick()} disabled={isCurrentUserInGroup || (typeof group !== 'undefined' && row.original.group_id === group) || row.original.members.length >= 5 || row.original.professorLock || row.original.studentLock || (row.original.sections !== currentStudent.sections)}>{t('group-table.join')}</Button>
                     {row.original.group_id === group && <Button color= "error" onClick={() => handleLeaveGroup()}> {t('common.Leave')} </Button>}
                     <Snackbar open={showAlert} onClose={handleAlertClose} anchorOrigin={{ vertical: 'top', horizontal: 'center' }}>
                       <Alert

--- a/client/src/components/studentsComponents/tables/StudentGroupTable.js
+++ b/client/src/components/studentsComponents/tables/StudentGroupTable.js
@@ -335,7 +335,7 @@ const StudentGroupTable = () => {
 
                 return (
                   <Box sx={{ display: 'flex', gap: '1rem', alignItems: 'center', justifyContent: 'center' }}>
-                    <Button onClick={() => handleJoinClick()} disabled={isCurrentUserInGroup || (typeof group !== 'undefined' && row.original.group_id === group) || row.original.members.length >= 5 || row.original.studentLock}>{t('group-table.join')}</Button>
+                    <Button onClick={() => handleJoinClick()} disabled={isCurrentUserInGroup || (typeof group !== 'undefined' && row.original.group_id === group) || row.original.members.length >= 5 || row.original.professorLock || row.original.studentLock}>{t('group-table.join')}</Button>
                     {row.original.group_id === group && <Button color= "error" onClick={() => handleLeaveGroup()}> {t('common.Leave')} </Button>}
                     <Snackbar open={showAlert} onClose={handleAlertClose} anchorOrigin={{ vertical: 'top', horizontal: 'center' }}>
                       <Alert

--- a/client/src/entities/Group.js
+++ b/client/src/entities/Group.js
@@ -5,7 +5,10 @@ class Group {
     this.professorEmail = groupData.professorEmail || ''
     this.members = groupData.members || []
     this.interest = groupData.interest || []
+    this.sections = groupData.sections || ''
     this.notes = groupData.notes || ''
+    this.studentLock = groupData.studentLock || false
+    this.professorLock = groupData.professorLock || false
   }
 
   get group_id () {
@@ -63,7 +66,10 @@ class Group {
       professorEmail: this.professorEmail,
       members: this.members,
       interest: this.interest,
-      notes: this.notes
+      sections: this.sections,
+      notes: this.notes,
+      studentLock: this.studentLock,
+      professorLock: this.professorLock
     }
   }
 }

--- a/client/src/entities/Section.js
+++ b/client/src/entities/Section.js
@@ -4,6 +4,7 @@ class Section {
     this._term = props.term || ''
     this._year = props.year || ''
     this._notes = props.notes || ''
+    this._lock = props.lock || false
   }
 
   // Getter methods
@@ -23,6 +24,10 @@ class Section {
     return this._notes
   }
 
+  get lock () {
+    return this._lock
+  }
+
   // Setter methods
   set name (name) {
     this._name = name
@@ -40,12 +45,17 @@ class Section {
     this._notes = notes
   }
 
+  set lock (lock) {
+    this._lock = lock
+  }
+
   toRequestBody () {
     return {
       name: this._name,
       term: this._term,
       year: this._year,
-      notes: this._notes
+      notes: this._notes,
+      lock: this._lock
     }
   }
 
@@ -54,7 +64,8 @@ class Section {
       name: this._name,
       term: this._term,
       year: this._year,
-      notes: this._notes
+      notes: this._notes,
+      lock: this._lock
     }
   }
 }

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -29,7 +29,9 @@
         "rows": "Rows",
         "log-out": "Log Out",
         "log-in": "Log In",
-        "Leave": "Leave"
+        "Leave": "Leave",
+        "lock-groups": "Lock Groups",
+        "status": "Status"
     },
     "table": {
         "student-id": "Student ID",

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -31,7 +31,9 @@
         "log-in": "Log In",
         "Leave": "Leave",
         "lock-groups": "Lock Groups",
-        "status": "Status"
+        "status": "Status",
+        "lock": "Lock",
+        "unlock": "Unlock"
     },
     "table": {
         "student-id": "Student ID",
@@ -75,7 +77,8 @@
         "project2": "Project:",
         "add-project": "Add Project",
         "leave-group": "Leave Group",
-        "no-project": "You have no project applications yet."
+        "no-project": "You have no project applications yet.",
+        "lock-group-message": "Control who can join your group"
     },
     "students-table": {
         "students": "Students",

--- a/client/src/locales/fr/translation.json
+++ b/client/src/locales/fr/translation.json
@@ -31,7 +31,9 @@
         "log-in": "Connecter",
         "Leave": "Quitter",
         "lock-groups": "Verrouiller les Groupes",
-        "status": "Statut"
+        "status": "Statut",
+        "lock": "Verrouiller",
+        "unlock": "Déverrouiller"
     },
     "table": {
         "student-id": "Identifiant",
@@ -75,7 +77,8 @@
         "project2": "Project :",
         "add-project": "Ajouter un projet",
         "leave-group": "Quitter le groupe",
-        "no-project": "Vous n'avez pas encore de candidatures à des projets."
+        "no-project": "Vous n'avez pas encore de candidatures à des projets.",
+        "lock-group-message": "Contrôlez qui peut rejoindre votre groupe"
     },
     "students-table": {
         "students": "Étudiants",

--- a/client/src/locales/fr/translation.json
+++ b/client/src/locales/fr/translation.json
@@ -29,7 +29,9 @@
         "rows": "Lignes",
         "log-out": "Déconnecter",
         "log-in": "Connecter",
-        "Leave": "Quitter"
+        "Leave": "Quitter",
+        "lock-groups": "Verrouiller les Groupes",
+        "status": "Statut"
     },
     "table": {
         "student-id": "Identifiant",

--- a/client/src/schemas/createGroupSchema.js
+++ b/client/src/schemas/createGroupSchema.js
@@ -18,6 +18,7 @@ const createGroupSchema = (groups, _id) => {
       }),
     // project: Yup.string().required("Project name is required"),
     // members: Yup.array().min(1, "At least one member is required"),
+    sections: Yup.string().required('Section is required'),
     notes: Yup.string()
   })
   return groupSchema

--- a/client/src/schemas/studentCreateGroupSchema.js
+++ b/client/src/schemas/studentCreateGroupSchema.js
@@ -1,0 +1,23 @@
+import * as Yup from 'yup'
+
+// Define the Yup schema for validation
+const studentCreateGroupSchema = (groups, _id) => {
+  const groupSchema = Yup.object().shape({
+    group_id: Yup.string()
+      .required('Group ID is required')
+      .transform((value) => value.trim())
+      .test('is-unique', 'Group ID already exists', function (value) {
+        if (groups && groups.length > 0) {
+          const group = groups.find(
+            (group) => group._id !== _id && group.group_id.toLowerCase() === value.toLowerCase()
+          )
+          return typeof group === 'undefined'
+        } else {
+          return true
+        }
+      }),
+    notes: Yup.string()
+  })
+  return groupSchema
+}
+export default studentCreateGroupSchema

--- a/client/src/services/groupService.js
+++ b/client/src/services/groupService.js
@@ -107,6 +107,46 @@ const groupService = {
       .catch((error) => {
         console.error(error)
       })
+  },
+  studentLockGroup: async (group) => {
+    return fetch('/api/group/update/student/lock', {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(group)
+    })
+      .then((response) => {
+        if (!response.ok) {
+          return response.text().then((errorMessage) => {
+            throw new Error(`Failed to lock group: ${errorMessage}`)
+          })
+        }
+        return { success: true, message: 'Group locked successfully' }
+      })
+      .catch((error) => {
+        console.error(error)
+      })
+  },
+  studentUnlockGroup: async (group) => {
+    return fetch('/api/group/update/student/unlock', {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(group)
+    })
+      .then((response) => {
+        if (!response.ok) {
+          return response.text().then((errorMessage) => {
+            throw new Error(`Failed to unlock group: ${errorMessage}`)
+          })
+        }
+        return { success: true, message: 'Group unlocked successfully' }
+      })
+      .catch((error) => {
+        console.error(error)
+      })
   }
 }
 

--- a/server/app/controllers/group_controller.py
+++ b/server/app/controllers/group_controller.py
@@ -3,7 +3,6 @@ from app.entities.GroupEntity import GroupEntity
 from app.models import group
 from bson import ObjectId, json_util
 from pymongo.errors import WriteError
-import pandas as pd
 import json
 from . import group_bp
  
@@ -38,7 +37,7 @@ def add_group():
         error_message = str(e)  # Get the error message as a string
         return {"message": error_message}, 500
 
-# PUT Request to update a student info
+# PUT Request to update a group info
 @group_bp.route("/group/update", methods=["PUT"])    
 def update_group_by_id():
     try:
@@ -51,6 +50,50 @@ def update_group_by_id():
             return {"message": "Invalid JSON data in the request body."}, 400
 
         result = group.update_group_by_id(group_id, group_obj)
+        if result:
+            return jsonify({"message": "Group updated successfully."}), 200
+        else:
+            return {"message": "Group not found or update failed."}, 404
+    except WriteError as e:
+        return {"message": "An error occurred while updating the group." + str(e)}, 500
+    except Exception as e:
+        return {"message": "An error occurred: " + str(e)}, 500
+    
+# PUT Request to update a group info
+@group_bp.route("/group/update/student/lock", methods=["PUT"])    
+def student_lock_group_by_id():
+    try:
+        group_obj = request.json       
+        group_id = group_obj["_id"]['$oid']
+        if not ObjectId.is_valid(group_id):
+            return {"message": "Invalid group ID."}, 400
+
+        if not group_obj:
+            return {"message": "Invalid JSON data in the request body."}, 400
+
+        result = group.student_lock_group_by_id(group_id, group_obj)
+        if result:
+            return jsonify({"message": "Group updated successfully."}), 200
+        else:
+            return {"message": "Group not found or update failed."}, 404
+    except WriteError as e:
+        return {"message": "An error occurred while updating the group." + str(e)}, 500
+    except Exception as e:
+        return {"message": "An error occurred: " + str(e)}, 500
+    
+# PUT Request to update a group info
+@group_bp.route("/group/update/student/unlock", methods=["PUT"])    
+def student_unlock_group_by_id():
+    try:
+        group_obj = request.json
+        group_id = group_obj["_id"]['$oid']  
+        if not ObjectId.is_valid(group_id):
+            return {"message": "Invalid group ID."}, 400
+
+        if not group_obj:
+            return {"message": "Invalid JSON data in the request body."}, 400
+
+        result = group.student_unlock_group_by_id(group_id, group_obj)
         if result:
             return jsonify({"message": "Group updated successfully."}), 200
         else:
@@ -101,7 +144,6 @@ def add_student_to_group():
 @group_bp.route("/remove/group/member/<id>", methods=["DELETE"])
 def remove_student_from_group(id):
     curr_user_email = session.get("user")["preferred_username"]
-    print(curr_user_email)
     if group.remove_student_from_group_by_email(id ,curr_user_email):
         return jsonify({"message": f"Removed {curr_user_email} to group "})
     else:

--- a/server/app/controllers/student_controller.py
+++ b/server/app/controllers/student_controller.py
@@ -166,6 +166,7 @@ def import_students():
             if student.get_student_by_username(res["username"]) is None:
                 res["sections"] = students_sections  # override the section
                 res["group"] = ''
+                res["email"] = res["email"].lower()
                 res["professorEmail"] = session.get("user")["preferred_username"]
                 student_id = ObjectId()
                 student_entity = StudentEntity(student_id, res)

--- a/server/app/entities/GroupEntity.py
+++ b/server/app/entities/GroupEntity.py
@@ -7,7 +7,10 @@ class GroupEntity:
         self._professorEmail = group_data.get('professorEmail', '')
         self._members = group_data.get('members', [])
         self._interest = group_data.get('interest', [])
+        self._sections = group_data.get('sections', '')
         self._notes = group_data.get('notes', '')
+        self._studentLock = group_data.get('studentLock', False)
+        self._professorLock = group_data.get('professorLock', False)
     
     def to_json(self):
         return {
@@ -16,7 +19,10 @@ class GroupEntity:
             'professorEmail': self._professorEmail,
             'members': self._members,
             'interest': self._interest,
+            'sections': self._sections,
             'notes': self._notes,
+            'studentLock': self._studentLock,
+            'professorLock': self._professorLock
         }
 
     @property

--- a/server/app/entities/SectionEntity.py
+++ b/server/app/entities/SectionEntity.py
@@ -6,13 +6,15 @@ class SectionEntity:
         self._term = Section_data.get('term', '')
         self._year = Section_data.get('year', '')
         self._notes = Section_data.get('notes', '')
+        self._lock = Section_data.get('lock', False)
         
     def to_json(self):
         return {
             'name': self._name,
             'term': self._term,
             'year': self._year,
-            'notes': self._notes
+            'notes': self._notes,
+            'lock': self._lock
         }
 
     @property
@@ -46,3 +48,11 @@ class SectionEntity:
     @notes.setter
     def notes(self, notes):
         self._notes = notes
+        
+    @property
+    def lock(self):
+        return self._lock
+    
+    @lock.setter
+    def lock(self, lock):
+        self._lock = lock

--- a/server/app/models/group.py
+++ b/server/app/models/group.py
@@ -79,6 +79,11 @@ def remove_student_from_group_by_email(group_id, email):
         return False
     group["members"].remove(student_obj["orgdefinedid"])
     student.remove_student_from_group(student_obj["orgdefinedid"])
+    
+    # unlock the group again
+    if "studentLock" in group and group["studentLock"]:
+        group["studentLock"] = False
+    
     result = groupCollection.update_one({"group_id": group_id},  {"$set" : group})
     return result
 
@@ -140,6 +145,48 @@ def update_group_by_id(id, group_obj):
         project.change_status(group_obj["project"], "Underway")
         
         result = groupCollection.update_one({"_id": ObjectId(id)}, {"$set": group_obj})
+        
+        return result.modified_count > 0
+    
+    except Exception as e:
+        return str(e)
+
+def student_lock_group_by_id(id, group_obj): 
+    try:
+        original_group = get_group(id)
+        group_obj.pop("_id", None)
+        
+        if not original_group:
+            return "Group not found"
+        
+        result = groupCollection.update_one(
+            {"_id": ObjectId(id)}, 
+            {"$set" : {
+                "studentLock": True
+                }
+            }
+        )
+        
+        return result.modified_count > 0
+    
+    except Exception as e:
+        return str(e)
+    
+def student_unlock_group_by_id(id, group_obj): 
+    try:
+        original_group = get_group(id)
+        group_obj.pop("_id", None)
+        
+        if not original_group:
+            return "Group not found"
+        
+        result = groupCollection.update_one(
+            {"_id": ObjectId(id)}, 
+            {"$set" : {
+                "studentLock": False
+                }
+            }
+        )
         
         return result.modified_count > 0
     

--- a/server/app/models/group.py
+++ b/server/app/models/group.py
@@ -144,7 +144,7 @@ def update_group_by_id(id, group_obj):
                 result = student.assign_group_to_student(orgdefinedId, groupName=group_obj["group_id"])
                 
         # Update the group lock if the section has changed
-        if original_group["sections"] != group_obj["sections"]:
+        if "sections" not in original_group or original_group["sections"] != group_obj["sections"]:
             group_obj["professorLock"] = _update_group_lock_for_new_section(group_obj["sections"])
         
         # Update old project if the group's project has been changed

--- a/server/app/models/section.py
+++ b/server/app/models/section.py
@@ -1,4 +1,4 @@
-from app.models import student
+from app.models import student, group
 from .__init__ import db
 from bson import ObjectId
 
@@ -30,11 +30,18 @@ def get_section_by_name(name):
 
 def update_section_by_id(id, section_obj):
     old_section_name = get_section_by_id(id)["name"]
+    old_section_lock = get_section_by_id(id)["lock"]
+    
     result = sectionsCollection.update_one({"_id": ObjectId(id)}, {
         "$set":section_obj.to_json()
     })
     if result and (old_section_name != section_obj.to_json()["name"]):
         _update_section_name_for_students(old_section_name, section_obj.to_json()["name"])
+        
+    # handle lock/unlock section
+    if result and (old_section_lock != section_obj.to_json()["lock"]):
+        _update_section_status_for_groups(section_obj.to_json()["name"], section_obj.to_json()["lock"])
+    
     return result.modified_count > 0
 
 def delete_section_by_id(a):
@@ -58,3 +65,8 @@ def _update_section_name_for_students(old_section_name, new_section_name):
     students = student.get_all_students_by_section(old_section_name)
     for st in students:
         _ = student.update_section_for_student(str(st["_id"]), new_section_name)
+        
+def _update_section_status_for_groups(section_name, section_lock):
+    groups = group.get_groups_by_section(section_name)
+    for gr in groups:
+        _ = group.professor_group_lock_status_by_id(gr["_id"], gr, section_lock)


### PR DESCRIPTION
### Change Description
<!-- Explain the changes you made. -->

- groups require having a section now
- prof can lock and unlock groups based on the section, a switch button is added in the edit section form
- a label "Locked" is added in the sections table to indicate if a section locked
- students can lock and unlock their groups
- students cannot join a group that has a different section than theirs
- students cannot leave their group if the professor locks all groups
- students cannot unlock their group if the professor locks all groups
- if a student leaves a locked group, the group gets unlocked again
- the group created by a student will have the same section as the student


### Related PR/Issues, JIRAs
<!-- Related Issues, PRs, etc. -->

### How to Verify
<!-- Explain how a reviewer can verify this works -->

### Verification
 - [ ] PR/Change is verified in local dev environment

### Tests
 - [ ] Unit tests added/updated
 - [ ] Integration tests added/updated
