### PR TITLE
Fix: Interested projects should have project applications

### DIFF
--- a/client/src/components/studentsComponents/tables/StudentGroupTable.js
+++ b/client/src/components/studentsComponents/tables/StudentGroupTable.js
@@ -137,7 +137,7 @@ const StudentGroupTable = () => {
 
       if (projects.projects && projects.message !== 'Project list is empty.') {
         const filteredProjects = projects.projects.filter(
-          (project) => project.status !== 'assigned'
+          (project) => project.status === 'Available'
         )
         setProjects(filteredProjects)
       }

--- a/server/app/entities/GroupEntity.py
+++ b/server/app/entities/GroupEntity.py
@@ -61,7 +61,7 @@ class GroupEntity:
     def interest(self):
         return self._interest
 
-    @members.setter
+    @interest.setter
     def interest(self, value):
         self._interest = value
 

--- a/server/app/models/student.py
+++ b/server/app/models/student.py
@@ -32,6 +32,13 @@ def get_student_by_email(email):
     document['_id'] = str(document['_id'])
     return document
 
+def get_student_email_by_orgdefinedid(orgdefinedid):
+    document = studentsCollection.find_one({"orgdefinedid": orgdefinedid})
+    student_email = ''
+    if document:
+        student_email = str(document['email'])
+    return student_email
+
 def get_student_name_from_email(email):
     fullName = ""
     document = studentsCollection.find_one({"email": email})


### PR DESCRIPTION
### Change Description
<!-- Explain the changes you made. -->
When a student creates a group, they can select the projects that they are interested in, these interested project should have a linked application to them when the student creates the group

### Related PR/Issues, JIRAs
<!-- Related Issues, PRs, etc. -->

### How to Verify
<!-- Explain how a reviewer can verify this works -->

### Verification
 - [ ] PR/Change is verified in local dev environment

### Tests
 - [ ] Unit tests added/updated
 - [ ] Integration tests added/updated
