### PR TITLE
Update python in server Dockerfile to 3.9

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8
+FROM python:3.9
 
 ARG PRIVATE_KEY
 


### PR DESCRIPTION
The system was failing to restart due to pipfile requiring Python 3.9. This fixes
